### PR TITLE
Migrate to new github issue template workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,5 @@
 PLEASE read the guidelines for contributing which is linked above.
+
 ### Issue description
 
 Describe your issue here, please try to structure your
@@ -8,12 +9,14 @@ mention whether it is a problem/bug or a suggestion.
 We can't read your thoughts.
 
 Please include details like:
+
 * AM logs / Full console error
 * Video of the bug / problem
 * The ingame name of the involved players
 * Your config file(s), if changed anything
 
 ### Core information
+
 **Spigot version**: insert
 
 **AM version**: insert
@@ -21,6 +24,7 @@ Please include details like:
 **Plugin list**: insert
 
 ### Special environment information
+
 Insert 'none' if you don't use it
 
 **ViaVersion version**: insert


### PR DESCRIPTION
This PR migrates the issue template to the new GitHub workflow as described in the docs: https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/about-issue-and-pull-request-templates

It also includes some minor formatting changes as suggested by markdownlint.